### PR TITLE
Add Ctrl+S shortcut for saving in MainWindow

### DIFF
--- a/Views/MainWindow.axaml.cs
+++ b/Views/MainWindow.axaml.cs
@@ -207,7 +207,6 @@ public partial class MainWindow : Window
 			}
 			catch
 			{
-
 				// Exception intentionally ignored
 			}
 		}
@@ -535,6 +534,7 @@ public partial class MainWindow : Window
 		BaseTextBox.FontSize = fontSize;
 	}
 
+	[Obsolete]
 	private void Window_KeyDown(object? sender, KeyEventArgs e)
 	{
 		if (e.KeyModifiers == KeyModifiers.Control && e.Key == Key.Z)
@@ -543,6 +543,12 @@ public partial class MainWindow : Window
 			Debug.WriteLine("Undo action triggered");
 #endif
 			_undoManager.UndoLast();
+		}
+
+		if(e.KeyModifiers == KeyModifiers.Control && e.Key == Key.S)
+		{
+			SaveFile_Button_Click(sender: sender, e: new RoutedEventArgs());
+			e.Handled = true; // Prevent further processing of this key event
 		}
 	}
 


### PR DESCRIPTION
Implements a keyboard shortcut (Ctrl+S) to trigger the save file action in the MainWindow.